### PR TITLE
Visual keys

### DIFF
--- a/dvtm.c
+++ b/dvtm.c
@@ -348,11 +348,12 @@ drawbar(void) {
 
 	if(keys) {
 		unsigned int keycount = 0;
-		while (keycount < MAX_KEYS && keys[keycount])
+		while (keycount < MAX_KEYS && keys[keycount]) {
 			if (keys[keycount] < ' ')
 				printw("^%c", 'a' - 1 + keys[keycount++]);
 			else
 				printw("%c", keys[keycount++]);
+		}
 	}
 
 	getyx(stdscr, y, x);

--- a/dvtm.c
+++ b/dvtm.c
@@ -220,6 +220,7 @@ extern Screen screen;
 static unsigned int waw, wah, wax, way;
 static Client *clients = NULL;
 static char *title;
+static KeyCombo keys;
 
 #include "config.h"
 
@@ -344,6 +345,15 @@ drawbar(void) {
 
 	attrset(TAG_NORMAL);
 	addstr(layout->symbol);
+
+	if(keys) {
+		unsigned int keycount = 0;
+		while (keycount < MAX_KEYS && keys[keycount])
+			if (keys[keycount] < ' ')
+				printw("^%c", 'a' - 1 + keys[keycount++]);
+			else
+				printw("%c", keys[keycount++]);
+	}
 
 	getyx(stdscr, y, x);
 	(void)y;
@@ -1712,7 +1722,6 @@ parse_args(int argc, char *argv[]) {
 
 int
 main(int argc, char *argv[]) {
-	KeyCombo keys;
 	unsigned int key_index = 0;
 	memset(keys, 0, sizeof(keys));
 	sigset_t emptyset, blockset;
@@ -1799,6 +1808,9 @@ main(int argc, char *argv[]) {
 					memset(keys, 0, sizeof(keys));
 					keypress(code);
 				}
+				drawbar();
+				if (is_content_visible(sel))
+					wnoutrefresh(sel->window);
 			}
 			if (r == 1) /* no data available on pty's */
 				continue;


### PR DESCRIPTION
Hi Marc,

I submitted this through email about a year ago, but I'm trying out the GitHub workflow now. 

This branch is to display command keypresses in the status bar while a multiple keypress command is being entered. Almost all commands in dvtm begin with MOD, so require multiple keypresses. Command keys are displayed as they are pressed, and appear between the layout symbol and the status text. The keys are cleared from the status bar after the final key of a command is pressed, or if the key combination is not bound to a command. For example, if your MOD is set to ^G and you are toggling the view of tag 4, it first displays '^g' after you press MOD, then '^gV' after you press 'V', and then is cleared after you complete the command by pressing '4'.

Thanks -Ross
