### PR TITLE
add spatial navigation

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -132,6 +132,10 @@ static KeyBinding bindings[] = {
 	{ { MOD, 'v', '0'      }, { view,           { NULL }                    } },
 	{ { MOD, 'v', '\t',    }, { viewprevtag,    { NULL }                    } },
 	{ { MOD, 't', '0'      }, { tag,            { NULL }                    } },
+  { { CTRL('j')          }, { focusdown,      { NULL }                    } },
+  { { CTRL('k')          }, { focusup,        { NULL }                    } },
+  { { CTRL('h')          }, { focusleft,      { NULL }                    } },
+  { { CTRL('l')          }, { focusright,     { NULL }                    } },
 	TAGKEYS( '1',                              0)
 	TAGKEYS( '2',                              1)
 	TAGKEYS( '3',                              2)
@@ -193,7 +197,12 @@ static Cmd commands[] = {
 	/* focus <win_id>: focus the window whose `DVTM_WINDOW_ID` is `win_id` */
 	{ "focus",  { focusid,	{ NULL } } },
 	/* tag <win_id> <tag> [tag ...]: add +tag, remove -tag or set tag of the window with the given identifier */
-	{ "tag",    { tagid,	{ NULL } } },
+	{ "tag",           { tagid,	    { NULL } } },
+  /* for control by editors and things */
+	{ "focusup",       { focusup,	    { NULL } } },
+	{ "focusdown",     { focusdown,	  { NULL } } },
+	{ "focusleft",     { focusleft,	  { NULL } } },
+	{ "focusright",    { focusright,	{ NULL } } },
 };
 
 /* gets executed when dvtm is started */

--- a/dvtm.c
+++ b/dvtm.c
@@ -185,6 +185,10 @@ static void focusnextnm(const char *args[]);
 static void focusprev(const char *args[]);
 static void focusprevnm(const char *args[]);
 static void focuslast(const char *args[]);
+static void focusup(const char *args[]);
+static void focusdown(const char *args[]);
+static void focusleft(const char *args[]);
+static void focusright(const char *args[]);
 static void killclient(const char *args[]);
 static void paste(const char *args[]);
 static void quit(const char *args[]);
@@ -1233,6 +1237,66 @@ static void
 focuslast(const char *args[]) {
 	if (lastsel)
 		focus(lastsel);
+}
+
+static void
+focusup(const char *args[]) {
+	if (!sel)
+		return;
+
+	unsigned short int x, y;
+	Client *c = sel;
+	x = c->x;
+	y = c->y;
+
+	Client * up = get_client_by_coord(x, y - 2);
+	if (up)
+		focus(up);
+}
+
+static void
+focusdown(const char *args[]) {
+	if (!sel)
+		return;
+
+	unsigned short int x, y;
+	Client *c = sel;
+	x = c->x;
+	y = c->y;
+
+	Client * up = get_client_by_coord(x, y + c->h + 1);
+	if (up)
+		focus(up);
+}
+
+static void
+focusleft(const char *args[]) {
+	if (!sel)
+		return;
+
+	unsigned short int x, y;
+	Client *c = sel;
+	x = c->x;
+	y = c->y;
+
+	Client * up = get_client_by_coord(x - 2, y);
+	if (up)
+		focus(up);
+}
+
+static void
+focusright(const char *args[]) {
+	if (!sel)
+		return;
+
+	unsigned short int x, y;
+	Client *c = sel;
+	x = c->x;
+	y = c->y;
+
+	Client * up = get_client_by_coord(x + c->w + 1, y);
+	if (up)
+		focus(up);
 }
 
 static void


### PR DESCRIPTION
I have a vim plugin that allows me to use the same bindings to move between vim panes and dvtm splits (similar to vim tmux navigator).

I've been using tmux recently but would like to switch back to dvtm, so I've resurrected this code.