### PR TITLE
Correct type of loop variable to avoid overflow

### DIFF
--- a/vt.c
+++ b/vt.c
@@ -1833,7 +1833,7 @@ static void init_colors(void)
 	 *      0 and 0. Initialize all color-pairs in order to have consistent
 	 *      behaviour despite the implementation used.
 	 */
-	for (short i = 1; i < COLOR_PAIRS; i++)
+	for (int i = 1; i < COLOR_PAIRS; i++)
 		init_pair(i, 0, 0);
 	vt_color_reserve(COLOR_WHITE, COLOR_BLACK);
 }


### PR DESCRIPTION
When `COLOR_PAIRS` is >= 32768, a `short` loop counter cannot cannot compare larger than `COLOR_PAIRS`, resulting in an infinite loop.

This was discovered as a freeze bug during testing where `COLOR_PAIRS` was 65535.

Additionally, at least on my system, the manpage for `COLOR_PAIRS` says it is declared as `int`.