### PR TITLE
Fix buffer corruption when title is updated

### DIFF
--- a/dvtm.c
+++ b/dvtm.c
@@ -558,6 +558,7 @@ settitle(Client *c) {
 	if (t && (term = getenv("TERM")) && !strstr(term, "linux")) {
 		printf("\033]0;%s\007", t);
 		fflush(stdout);
+		wnoutrefresh(c->window);
 	}
 }
 


### PR DESCRIPTION
This was tested with Kakoune, which reliably was able to dirty the buffer
whenever I press the right arrow key. (Go figure.)

This should fix #80 and #53; possibly #61 and #20.