### PR TITLE
copymode: Place cursor at end of buffer content

### DIFF
--- a/dvtm.c
+++ b/dvtm.c
@@ -1112,7 +1112,7 @@ copymode(const char *args[]) {
 
 	const char *argv[3] = { args[0], NULL, NULL };
 	char argline[32];
-	int line = vt_content_start(sel->app);
+	int line = 1 + vt_content_end(sel->app);
 	snprintf(argline, sizeof(argline), "+%d", line);
 	argv[1] = argline;
 

--- a/vt.c
+++ b/vt.c
@@ -1966,3 +1966,9 @@ int vt_content_start(Vt *t)
 {
 	return t->buffer->scroll_above;
 }
+
+int vt_content_end(Vt *t)
+{
+	int curs_row = t->buffer->curs_row - t->buffer->lines;
+	return vt_content_start(t) + curs_row;
+}

--- a/vt.h
+++ b/vt.h
@@ -62,5 +62,6 @@ void vt_noscroll(Vt*);
 pid_t vt_pid_get(Vt*);
 size_t vt_content_get(Vt*, char **s, bool colored);
 int vt_content_start(Vt*);
+int vt_content_end(Vt*);
 
 #endif /* VT_H */


### PR DESCRIPTION
More convenient as that's where the most recent command and output is.
Additionally the original code placed the cursor one line off (base 0,
but vis expects base 1).