### PR TITLE
copymode: Set cwd so paths make sense in editor

### DIFF
--- a/dvtm.c
+++ b/dvtm.c
@@ -1116,7 +1116,8 @@ copymode(const char *args[]) {
 	snprintf(argline, sizeof(argline), "+%d", line);
 	argv[1] = argline;
 
-	if (vt_forkpty(sel->editor, args[0], argv, NULL, NULL, to, from) < 0) {
+	char *cwd = getcwd_by_pid(sel);
+	if (vt_forkpty(sel->editor, args[0], argv, cwd, NULL, to, from) < 0) {
 		vt_destroy(sel->editor);
 		sel->editor = NULL;
 		return;


### PR DESCRIPTION
...to work with grep and friends, particularly useful with `vis-goto-file` plugin.