### PR TITLE
Ensure cursor is clamped after buffer swap

### DIFF
--- a/vt.c
+++ b/vt.c
@@ -971,6 +971,7 @@ static void interpret_csi_priv_mode(Vt *t, int param[], int pcount, bool set)
 			if (!set)
 				buffer_clear(&t->buffer_alternate);
 			t->buffer = set ? &t->buffer_alternate : &t->buffer_normal;
+			cursor_clamp(t);
 			vt_dirty(t);
 			if (param[i] != 1049)
 				break;


### PR DESCRIPTION
vt_resize resizes both buffers of the given Vt* (involving a realloc),
but can only correctly clamp the cursor of the active buffer. This means
that when it comes time to switch to the other buffer in
interpret_csi_priv_mode, we might be switching to a buffer which has a
cursor pointing to old memory. Thus, when we switch buffers it's
necessary to ensure the cursor is clamped to avoid memory errors.

This is a bug I've observed for a few years but never often enough to
worry me. After I was able to pin it down to activities such as opening
of manpages and resizing terminals, I boiled it down to be reproducible
as:

1. Open a manpage in dvtm, buffer swap to alt
2. Close the manpage and return to the shell, buffer swaps to norm
3. Resize the pane to have fewer rows than before, alt+norm are resized
   but only norm has its cursor clamped
4. Open a manpage again, UAF causes crash since unclamped curs_row on
   alt buffer is still pointing to before-resize allocation

With some exploratory testing I have seen crashes identical and nearly
identical to the following fixed by this patch:

* Fixes https://github.com/martanne/dvtm/issues/73
* Fixes https://github.com/martanne/dvtm/issues/74