### PR TITLE
Use pkg-config to find curses libs if possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,36 +10,13 @@ DEBUG_CFLAGS = ${CFLAGS} -UNDEBUG -O0 -g -ggdb -Wall -Wextra -Wno-unused-paramet
 
 
 # Guess CURSESLIB and LIBS but prefer the user choices if possible
-NEWCURSES = "$(shell pkg-config --libs curses)"
-ifeq ($(.SHELLSTATUS),0)
-	CURSESLIB = $(NEWCURSES)
-endif
-
-NEWCURSES = "$(shell pkg-config --libs cursesw)"
-ifeq ($(.SHELLSTATUS),0)
-	CURSESLIB = $(NEWCURSES)
-endif
-
-NEWCURSES = "$(shell pkg-config --libs ncurses)"
-ifeq ($(.SHELLSTATUS),0)
-	CURSESLIB = $(NEWCURSES)
-endif
-
-NEWCURSES = "$(shell pkg-config --libs ncursesw)"
-ifeq ($(.SHELLSTATUS),0)
-	CURSESLIB = $(NEWCURSES)
-endif
-
-NEWCURSES = "$(shell pkg-config --libs $(CURSESLIB))"
-ifeq ($(.SHELLSTATUS),0)
-	CURSESLIB = $(NEWCURSES)
-endif
-
-ifeq ("$(shell basename $(shell command -v pkg-config))", "pkg-config")
+ifeq ("$(shell basename $(shell command -v pkg-config))","pkg-config")
+    pkgconfig = $(and $(findstring 0,$(and $(shell pkg-config --libs $(i)),$(.SHELLSTATUS))),$(i))
+    var := i # i or something
+    list := curses cursesw ncurses ncursesw
+    CURSESLIB = $(foreach $(var), $(list), $(pkgconfig))
     LIBS := $(shell pkg-config --libs $(CURSESLIB))
 endif
-
-
 
 all: dvtm dvtm-editor
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,39 @@ VERSION = $(shell git describe --always --dirty 2>/dev/null || echo "0.15-git")
 CFLAGS += -DVERSION=\"${VERSION}\"
 DEBUG_CFLAGS = ${CFLAGS} -UNDEBUG -O0 -g -ggdb -Wall -Wextra -Wno-unused-parameter
 
+
+# Guess CURSESLIB and LIBS but prefer the user choices if possible
+NEWCURSES = "$(shell pkg-config --libs curses)"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+NEWCURSES = "$(shell pkg-config --libs cursesw)"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+NEWCURSES = "$(shell pkg-config --libs ncurses)"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+NEWCURSES = "$(shell pkg-config --libs ncursesw)"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+NEWCURSES = "$(shell pkg-config --libs $(CURSESLIB))"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+ifeq ("$(shell basename $(shell command -v pkg-config))", "pkg-config")
+    LIBS := $(shell pkg-config --libs $(CURSESLIB))
+endif
+
+
+
 all: dvtm dvtm-editor
 
 config.h:

--- a/config.mk
+++ b/config.mk
@@ -6,8 +6,15 @@ MANPREFIX = ${PREFIX}/share/man
 # leave empty to install into your home folder
 TERMINFO := ${DESTDIR}${PREFIX}/share/terminfo
 
+CURSESLIB = ncursesw
+
 INCS = -I.
 LIBS = -lc -lutil -lncursesw
+
+ifeq ("$(shell basename $(shell command -v pkg-config))", "pkg-config")
+    LIBS := $(shell pkg-config --libs $(CURSESLIB))
+endif
+
 CPPFLAGS = -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED
 CFLAGS += -std=c99 ${INCS} -DNDEBUG ${CPPFLAGS}
 

--- a/config.mk
+++ b/config.mk
@@ -11,10 +11,6 @@ CURSESLIB = ncursesw
 INCS = -I.
 LIBS = -lc -lutil -lncursesw
 
-ifeq ("$(shell basename $(shell command -v pkg-config))", "pkg-config")
-    LIBS := $(shell pkg-config --libs $(CURSESLIB))
-endif
-
 CPPFLAGS = -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED
 CFLAGS += -std=c99 ${INCS} -DNDEBUG ${CPPFLAGS}
 


### PR DESCRIPTION
Find the libs for ncurses if the pkg-config command is available. Some
view this as an opinionated change (since ncurses should fix it instead),
but I think it is a good choice.